### PR TITLE
Localisation settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -33,8 +33,8 @@ from mycroft.util.log import LOG
 from mycroft.audio import wait_while_speaking
 
 # Static values for tunein search requests
-search_url = "http://api.iheart.com/api/v3/search/all"
-station_url = "https://api.iheart.com/api/v2/content/liveStations/"
+search_url = "http://au.api.iheart.com/api/v3/search/all"
+station_url = "https://au.api.iheart.com/api/v2/content/liveStations/"
 headers = {}
 
 class IHeartRadioSkill(CommonPlaySkill):
@@ -93,7 +93,9 @@ class IHeartRadioSkill(CommonPlaySkill):
 
     @intent_file_handler('StreamRequest.intent')
     def handle_stream_intent(self, message):
-        self.find_station(message.data["station"])
+        search_term = 'triplej' if (message.data["station"] == 'triple j') \
+            else message.data["station"]
+        self.find_station(search_term)
         LOG.debug("Station data: " + message.data["station"])
 
     def find_station(self, search_term):

--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -1,0 +1,10 @@
+name: i Heart Radio
+skillMetadata:
+  sections:
+    - name: Country
+      fields:
+        - name: country
+          type: select
+          label: Change location for search results
+          options: Default (use device location)|default;Global|global;Australia|au;New Zealand|nz
+          value: default


### PR DESCRIPTION
Hi John,

As I mentioned in the forum, I found I needed to localise this to get the Australian channels I wanted so I went one extra step and added a setting to be able to configure this. 

By default it will use the location of your device, as defined in your device settings, check to see if an API with that country codes subdomain returns a 200, then uses that. If not, it will use the default API. Users can also change the skill settings to use either Global (normal API), Australia or NZ based search. These were the only country codes I found that worked but I didn't try to test them all.

Also if you try it out, the settings block for this shows up at the bottom of the list as I left the lowercase 'i' in. We should be doing a case insensitive sort on skill setting titles in that list so I think it's better that we fix that on the backend.

If you're not wanting to complicate your skill with settings, feel free to reject this, I was just halfway there so figured I should wrap it up and contribute it back :)

Thanks again for a great Skill!
