### PR TITLE
Require vlc-bin rather than the main package.

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -2,5 +2,5 @@
 
 sudo apt-get update
 
-sudo apt-get install -yq vlc
+sudo apt-get install -yq vlc-bin vlc-plugin-base
 exit 0


### PR DESCRIPTION
Requiring these two vlc packages instead of the main vlc one means installing something like 185mb less on the current raspbian picroft, and they seem to provide everything necessary to use vlc through the mycroft VlcService.