### PR TITLE
Switch to new settings callback definition

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -45,8 +45,10 @@ class IHeartRadioSkill(CommonPlaySkill):
         self.station_id = None
         self.stream_url = None
         self.regexes = {}
+
+    def initialize(self):
+        self.settings_change_callback = self.set_urls
         self.set_urls()
-        self.settings.set_changed_callback(self.set_urls)
 
     def set_urls(self):
         country = self.settings.get('country', 'default')


### PR DESCRIPTION
The mechanism to register the callback method has changed. See:
https://mycroft-core.readthedocs.io/en/latest/source/mycroft.html?highlight=callback#mycroft.MycroftSkill.settings_change_callback

This also shifts the set_urls call to the initialize method so it doesn't run until after the settings have been populated.
