### PR TITLE
Updated UI to handle Previous Played and Mute Commercials

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,13 +48,14 @@ class IHeartRadioSkill(CommonPlaySkill):
         self.regexes = {}
         self.set_urls()
         self.mute_commercials = False
-        self.settings_changed_callback = self.set_urls
 
     def initialize(self):
         self.gui.register_handler('skill.pause.event', self.handle_pause_event)
         self.gui.register_handler('skill.timer.event', self.setCurrentTrack)
         self.gui.register_handler('skill.mute.event', self.handle_mute_event)
         self.gui.register_handler('skill.volume.event', self.handle_volume_event)
+        self.settings_change_callback = self.set_urls
+        self.set_urls()
 
     def handle_pause_event(self, message):
         if self.audio_state == "playing":

--- a/__init__.py
+++ b/__init__.py
@@ -168,6 +168,7 @@ class IHeartRadioSkill(CommonPlaySkill):
             # query the station URL using the ID
             station_res = requests.get(self.station_url+str(self.station_id))
             station_obj = json.loads(station_res.text)
+            LOG.debug("Logo Url: "+station_obj["hits"][0]["logo"])
             self.audio_state = "playing"
             self.gui["audio_state"] = "playing"
             self.speak_dialog("now.playing", {"station": self.station_name} )

--- a/ui/controls.qml
+++ b/ui/controls.qml
@@ -2,122 +2,318 @@ import QtQuick.Layouts 1.4
 import QtQuick 2.4
 import QtQuick.Controls 2.0
 import org.kde.kirigami 2.4 as Kirigami
-
 import Mycroft 1.0 as Mycroft
 
-
+//
+// This is designed and built for a 7" screen, but should resize pretty well regardless of screensize.
+// I doubt this would work very well on a Mark2 screen. :(
+//
 Mycroft.Delegate {
     id: root
-    property var album_img: sessionData.image
-    ColumnLayout {
-        spacing: 2
-        anchors.centerIn: parent
-        Layout.fillWidth: true
-        Layout.alignment: Qt.AlignHCenter
+    visible: true
 
-        RowLayout {
-            id: stationGrid
-            Layout.fillWidth: true
+    function handlePlayPauseTimer() {
+        if(sessionData.audio_state === "playing") {
+            refreshTimer.stop()
+        } else {
+            refreshTimer.start()
+        }
+    }
+
+    RowLayout {
+        spacing: 2
+        anchors.fill: parent
+        Column {
+            spacing: 2
+            Layout.preferredWidth: 0.8*parent.height
+            Layout.preferredHeight: parent.height
             Image {
                 Layout.alignment: Qt.AlignHCenter
-                id: img
+                id: stationImg
                 source: Qt.resolvedUrl(sessionData.logoURL)
-                Layout.preferredWidth: 300
-                Layout.preferredHeight: 350
+                width: parent.width
+                height: parent.width
                 fillMode: Image.PreserveAspectFit
             }
-            Kirigami.Label {
-                id: description
-                Layout.alignment: Qt.AlignHCenter
-                Layout.fillWidth: true
-                Layout.preferredHeight: 50
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.WordWrap
-                elide: Text.ElideRight
-                font.family: "Noto Sans"
+            Rectangle {
+                id: stationRect
+                anchors.top: stationImg.top
+                width: parent.width
+                height: parent.width
+                color: "transparent"
+                border.color: "white"
+                border.width: 2
+                radius: 20
+            }
+            Label {
+                id: stationDescription
+                anchors.top: stationRect.bottom
+                width: parent.width
+                height: 0.4*(parent.height - parent.width)
                 font.bold: true
                 font.weight: Font.Bold
-                font.pixelSize: 30
+                font.pixelSize: .04*parent.height
                 text: sessionData.description
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+            }
+            Row {
+                spacing: 10
+                width: parent.width
+                anchors.top: stationDescription.bottom
+                height: 0.6*(parent.height - parent.width)
+                Rectangle {
+                    width: 20
+                    height: parent.height
+                    color: "transparent"
+                }
+                Image {
+                    id: playPauseImg
+                    height: parent.height
+                    width: parent.height
+                    source: Qt.resolvedUrl(sessionData.playPauseImage)
+                    MouseArea {
+                        id: apause
+                        onClicked: {
+                            handlePlayPauseTimer()
+                            triggerGuiEvent("skill.pause.event", {"click": "CLICK"})
+                        }
+                    }
+                }
+                Rectangle {
+                    id: playPauseSpacer
+                    anchors.left: playPauseImg.right
+                    width: 40
+                    height: parent.height
+                    color: "transparent"
+                }
+                Label {
+                    id: volumeLabel
+                    anchors.left: playPauseSpacer.right
+                    font.bold: false
+                    font.pixelSize: 10
+                    text: "Volume"
+                    width: 0.3*parent.width 
+                    horizontalAlignment: Text.AlignHCenter
+                }
+                Slider {
+                    id: volumeSlider
+                    width: 0.3*parent.width 
+                    anchors.left: playPauseSpacer.right
+                    anchors.top: volumeLabel.bottom
+                    from: 0
+                    value: 5
+                    to: 10
+                    stepSize: 1
+                    onMoved: {
+                        triggerGuiEvent("skill.volume.event", {"level": volumeSlider.value})
+                    }
+                }
+                CheckBox {
+                    id: muteCommercials
+                    anchors.left: volumeSlider.right
+                    anchors.top: stationDescription.bottom
+                    checked: false
+                    text: "Mute\nCommercials"
+                    onClicked: {
+                        triggerGuiEvent("skill.mute.event", {"state": muteCommercials.checked})
+                    }
+                }
             }
         }
-        RowLayout {
-            id: trackGrid
+        Column {
+            spacing: 0
             Layout.fillWidth: true
-            Image {
-                Layout.alignment: Qt.AlignHCenter
-                id: trackimg
-                source: Qt.resolvedUrl(sessionData.currentTrackImg)
-                Layout.preferredWidth: 200
-                Layout.preferredHeight: 200
-                fillMode: Image.PreserveAspectFit
+            Layout.preferredHeight: parent.height
+            Rectangle {
+                height: 20
+                width: parent.width
+                color: "transparent"
             }
-            ColumnLayout {
-                spacing: 1
-                Layout.alignment: Qt.AlignHCenter
+            Row {
+                spacing: 0
+                width: parent.width
+                height: (0.5*parent.height)-20
+                Rectangle {
+                    height: parent.height
+                    width: 20
+                    color: "transparent"
+                }
+                Image {
+                    id: currentTrackImage
+                    source: Qt.resolvedUrl(sessionData.currentTrackImg)
+                    width: parent.height-20
+                    height: parent.height-20
+                }
 
-                Kirigami.Label {
-                    id: currentTrackTitle
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 50
-                    horizontalAlignment: Text.AlignHLeft
-                    wrapMode: Text.WordWrap
-                    elide: Text.ElideRight
-                    font.family: "Noto Sans"
-                    font.bold: true
-                    font.weight: Font.Bold
-                    font.pixelSize: 25
-                    text: sessionData.title
+                Rectangle {
+                    height: parent.height
+                    width: 20
+                    color: "transparent"
                 }
-                Kirigami.Label {
-                    id: currentTrackArtist
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 40
-                    horizontalAlignment: Text.AlignHLeft
-                    wrapMode: Text.WordWrap
-                    elide: Text.ElideRight
-                    font.family: "Noto Sans"
-                    font.bold: false
-                    font.pixelSize: 20
-                    text: sessionData.artist
-                }
-                Kirigami.Label {
-                    id: currentTrackAlbum
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 40
-                    horizontalAlignment: Text.AlignHLeft
-                    wrapMode: Text.WordWrap
-                    elide: Text.ElideRight
-                    font.family: "Noto Sans"
-                    font.bold: false
-                    font.pixelSize: 20
-                    text: sessionData.album
+                Column {
+                    spacing: 5
+                    width: parent.width-parent.height-40
+                    height: parent.height-20
+                    Label {
+                        font.pixelSize: .1*parent.height
+                        font.bold: true
+                        font.weight: Font.Bold
+                        text: sessionData.title
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                    }
+                    Label {
+                        font.bold: false
+                        text: sessionData.artist
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                    }
+                    Label {
+                        font.bold: false
+                        text: sessionData.album
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                    }
                 }
             }
-        }
-        RowLayout {
-            id: grid
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
-
-            Image {
-                height: 200
-                source: Qt.resolvedUrl(sessionData.playPauseImage)
-                opacity: apause.pressed ? 0.5 : 1.0
-                MouseArea {
-                    id: apause
-                    anchors.fill: parent
-                    onClicked: triggerGuiEvent("skill.pause.event", {"click": "CLICK"})
+            Label {
+                font.bold: true
+                font.pixelSize: 20
+                text: " Recently Played"
+            }
+            Row {
+                spacing: 0
+                width: parent.width
+                height: (0.5*parent.height)-20
+                Rectangle {
+                    height: parent.height
+                    width: 20
+                    color: "transparent"
+                }
+                Column {
+                    spacing: 3
+                    width: (.33*parent.width)-20
+                    height: parent.height
+                    Image {
+                        id: previous1Img
+                        source: Qt.resolvedUrl(sessionData.previous1Img)
+                        width: parent.width-20
+                        height: parent.width-20
+                    }
+                    Label {
+                        font.bold: true
+                        font.pixelSize: 10
+                        text: sessionData.previous1Title
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                    Label {
+                        font.bold: false
+                        font.pixelSize: 10
+                        text: sessionData.previous1Artist
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                    Label {
+                        font.bold: false
+                        font.pixelSize: 10
+                        text: sessionData.previous1Album
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                }
+                Rectangle {
+                    height: parent.height
+                    width: 20
+                    color: "transparent"
+                }
+                Column {
+                    spacing: 3
+                    width: (.33*parent.width)-20
+                    height: parent.height
+                    Image {
+                        id: previous2Img
+                        source: Qt.resolvedUrl(sessionData.previous2Img)
+                        width: parent.width-20
+                        height: parent.width-20
+                    }
+                    Label {
+                        font.bold: true
+                        font.pixelSize: 10
+                        text: sessionData.previous2Title
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                    Label {
+                        font.bold: false
+                        font.pixelSize: 10
+                        text: sessionData.previous2Artist
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                    Label {
+                        font.bold: false
+                        font.pixelSize: 10
+                        text: sessionData.previous2Album
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                }
+                Rectangle {
+                    height: parent.height
+                    width: 20
+                    color: "transparent"
+                }
+                Column {
+                    spacing: 3
+                    width: (.33*parent.width)-20
+                    height: parent.height
+                    Image {
+                        id: previous3Img
+                        source: Qt.resolvedUrl(sessionData.previous3Img)
+                        width: parent.width-20
+                        height: parent.width-20
+                    }
+                    Label {
+                        font.bold: true
+                        font.pixelSize: 10
+                        text: sessionData.previous3Title
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                    Label {
+                        font.bold: false
+                        font.pixelSize: 10
+                        text: sessionData.previous3Artist
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
+                    Label {
+                        font.bold: false
+                        font.pixelSize: 10
+                        text: sessionData.previous3Album
+                        wrapMode: Text.WordWrap
+                        width: parent.width-20
+                        lineHeight: 1.0
+                    }
                 }
             }
         }
     }
     Timer {
+        id: refreshTimer
         interval: 10000; running: true; repeat: true
-        onTriggered: triggerGuiEvent("skill.timer.event", {"click": "CLICK"})
+        onTriggered: {
+            triggerGuiEvent("skill.timer.event", {"click": "CLICK"})
+        }
     }
-    
 }

--- a/ui/controls.qml
+++ b/ui/controls.qml
@@ -18,6 +18,7 @@ Mycroft.Delegate {
         } else {
             refreshTimer.start()
         }
+        triggerGuiEvent("skill.pause.event", {"click": "CLICK"})
     }
 
     RowLayout {
@@ -73,11 +74,9 @@ Mycroft.Delegate {
                     width: parent.height
                     source: Qt.resolvedUrl(sessionData.playPauseImage)
                     MouseArea {
+                        anchors.fill: parent
                         id: apause
-                        onClicked: {
-                            handlePlayPauseTimer()
-                            triggerGuiEvent("skill.pause.event", {"click": "CLICK"})
-                        }
+                        onClicked: { handlePlayPauseTimer() }
                     }
                 }
                 Rectangle {


### PR DESCRIPTION
A whole new layout designed for a 7" screen, but should work for most screen sizes.
I added the ability to mute/pause during commercials.  It is able to do this because most stations return a 204 call on "Currently Playing" when there are long talk sessions or commercials.
Here are some screenshots.
![2020-06-10-203700_800x480_scrot](https://user-images.githubusercontent.com/13670845/84467303-fc581b00-ac38-11ea-94b0-a213adc86a79.png)

![2020-06-11-212220_800x480_scrot](https://user-images.githubusercontent.com/13670845/84467309-00843880-ac39-11ea-8b96-a610e1c9f10e.png)

![2020-06-11-225445_800x480_scrot](https://user-images.githubusercontent.com/13670845/84467313-0417bf80-ac39-11ea-9f88-ccb8f90c762c.png)

